### PR TITLE
feat: Add new PR templeate when we use a new branch

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,0 +1,44 @@
+# What is the problem?
+
+Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Include any link to an issue.
+
+# Explain your solution
+
+Describe, at a high level, what was done to affect change. Introduce a red/black tree to increase search speed or remove `troublesome module X`, which was causing `specific description of issue introduced by module` are good examples.
+
+If your change is obvious, you may be able to omit addressing this question.
+
+# Preview
+
+If possible add the URL of your changes deployed on some ephimeral instance to preview your solution. If not possible add relevant screenshots addressing your solution.
+
+## Update file(s)
+
+* List all file changes in the project with relative path
+
+## New file(s)
+
+* List all new files and new paths if exists
+
+# Type of change
+
+Please mark the options that apply.
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+
+# Checklist:
+
+Please make sure everything is marked as much as possible.
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+- [ ] Any dependent changes have been merged and published in downstream modules
+- [ ] I have checked my code and corrected any misspellings/orthography


### PR DESCRIPTION
# What is the problem?

The project doesn't have a PR template

# Explain your solution

Fork PR template from Secret project

## New file(s)

* docs/pull_request_template.md

# Type of change

Please mark the options that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

Please make sure everything is marked as much as possible.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings/orthography