### PR TITLE
fix: disable the debug banner when we installed the app

### DIFF
--- a/lib/App/app.dart
+++ b/lib/App/app.dart
@@ -7,6 +7,7 @@ class MyApp extends StatelessWidget {
 	@override
 	Widget build(BuildContext context) {
 		return MaterialApp(
+			debugShowCheckedModeBanner: false,
 			title: 'Flutter Demo',
 			theme: ThemeData(
 				primarySwatch: Colors.brown,


### PR DESCRIPTION
# What is the problem?

When we install the app in a device, the same application show us a banner

# Explain your solution

Change a flag when we installed the app

# Preview

![image](https://user-images.githubusercontent.com/33945793/145695158-7077e8f7-bb4c-4097-9b6a-d5471e5f704f.png)

![image](https://user-images.githubusercontent.com/33945793/145695161-544d5c24-21e9-4253-9e21-427b2700253d.png)


## Update file(s)

* lib/App/app.dart

# Type of change

Please mark the options that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

Please make sure everything is marked as much as possible.

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings/orthography
